### PR TITLE
Fix panic function argument parser

### DIFF
--- a/src/library/lexer/tokenizer.rs
+++ b/src/library/lexer/tokenizer.rs
@@ -30,7 +30,7 @@ impl<'a> Tokenizer<'a> {
         let self_object = Tokenizer {
             position: 0,
             id: 0,
-            line_no: 0,
+            line_no: 1,
             current_char: BLACK_HOLE,
             length: text.len(),
             token: token,
@@ -50,7 +50,7 @@ impl<'a> Tokenizer<'a> {
             match self.current_char {
                 '\n' => {
                     self.line_no += 1;
-                    self.current_char = self.get_next_char()
+                    self.current_char = self.get_next_char();
                 }
 
                 ' ' | '\t' => {
@@ -324,7 +324,7 @@ impl<'a> Tokenizer<'a> {
                 }
 
                 // could be address or bitwise operator
-                // TODO : how to find address off operator
+                // TODO : how to find address off operator?
                 //      If left side expression is not rvalue then it must be address off,
                 '&' => {
                     self.push_advance();
@@ -390,9 +390,15 @@ impl<'a> Tokenizer<'a> {
                     match self.current_char {
                         '*' => {
                             // start of multi line comment
+                            let mut line_num = self.line_no;
+
                             loop {
                                 self.push_advance();
-                                if self.current_char == '*' {
+
+                                if self.current_char == '\n' {
+                                    //count the new lines
+                                    line_num += 1;
+                                } else if self.current_char == '*' {
                                     self.push_advance();
                                     if self.current_char == '/' {
                                         self.push_advance();
@@ -400,7 +406,11 @@ impl<'a> Tokenizer<'a> {
                                             TokenType::MultilineComment,
                                             TokenKind::Comments,
                                         );
+                                        self.line_no = line_num;
                                         break;
+                                    } else if self.current_char == '\n' {
+                                        //count the new lines
+                                        line_num += 1;
                                     }
                                 }
                             }
@@ -638,7 +648,7 @@ mod test {
         assert_eq!(tok.token_buffer[0].get_token_type(), TokenType::Identifier);
         assert_eq!(tok.token_buffer[0].get_token_kind(), TokenKind::Identifiers);
         assert_eq!(tok.token_buffer[0].get_token_value(), String::from("a"));
-        assert_eq!(tok.token_buffer[0].get_token_line_num(), 0);
+        assert_eq!(tok.token_buffer[0].get_token_line_num(), 1);
         assert_eq!(0, tok.token.len());
 
         tok.push_advance();
@@ -649,7 +659,7 @@ mod test {
             TokenKind::AssignmentOperators
         );
         assert_eq!(tok.token_buffer[1].get_token_value(), String::from("="));
-        assert_eq!(tok.token_buffer[1].get_token_line_num(), 0);
+        assert_eq!(tok.token_buffer[1].get_token_line_num(), 1);
 
         tok.push_advance();
         tok.push_advance();
@@ -658,7 +668,7 @@ mod test {
         assert_eq!(tok.token_buffer[2].get_token_type(), TokenType::StringValue);
         assert_eq!(tok.token_buffer[2].get_token_kind(), TokenKind::Values);
         assert_eq!(tok.token_buffer[2].get_token_value(), String::from("\"2\""));
-        assert_eq!(tok.token_buffer[2].get_token_line_num(), 0);
+        assert_eq!(tok.token_buffer[2].get_token_line_num(), 1);
         assert_eq!(0, tok.token.len());
     }
 
@@ -666,603 +676,649 @@ mod test {
     fn test_tokenize_keywords() {
         let text = read_file("src/test/resources/tokenize_keywords.cpp");
         let mut tok = Tokenizer::new(&text);
-        let tok_vector = vec![
+        let expected = vec![
             Token::new(
                 String::from("signed"),
                 TokenKind::Modifiers,
                 TokenType::Signed,
-                0,
+                1,
                 0,
             ),
             Token::new(
                 String::from("unsigned"),
                 TokenKind::Modifiers,
                 TokenType::Unsigned,
-                1,
+                2,
                 1,
             ),
             Token::new(
                 String::from("class"),
                 TokenKind::Keyword,
                 TokenType::KeywordClass,
-                2,
+                3,
                 2,
             ),
             Token::new(
                 String::from("new"),
                 TokenKind::Keyword,
                 TokenType::KeywordNew,
-                3,
+                4,
                 3,
             ),
             Token::new(
                 String::from("while"),
                 TokenKind::Keyword,
                 TokenType::KeywordWhile,
-                4,
+                5,
                 4,
             ),
             Token::new(
                 String::from("for"),
                 TokenKind::Keyword,
                 TokenType::KeywordFor,
-                5,
+                6,
                 5,
             ),
             Token::new(
                 String::from("do"),
                 TokenKind::Keyword,
                 TokenType::KeywordDo,
-                6,
+                7,
                 6,
             ),
             Token::new(
                 String::from("break"),
                 TokenKind::Keyword,
                 TokenType::KeywordBreak,
-                7,
+                8,
                 7,
             ),
             Token::new(
                 String::from("continue"),
                 TokenKind::Keyword,
                 TokenType::KeywordContinue,
-                8,
+                9,
                 8,
             ),
             Token::new(
                 String::from("switch"),
                 TokenKind::Keyword,
                 TokenType::KeywordSwitch,
-                9,
+                10,
                 9,
             ),
             Token::new(
                 String::from("if"),
                 TokenKind::Keyword,
                 TokenType::KeywordIf,
-                10,
+                11,
                 10,
             ),
             Token::new(
                 String::from("else"),
                 TokenKind::Keyword,
                 TokenType::KeywordElse,
-                11,
+                12,
                 11,
             ),
             Token::new(
                 String::from("public"),
                 TokenKind::Modifiers,
                 TokenType::KeywordPublic,
-                12,
+                13,
                 12,
             ),
             Token::new(
                 String::from("private"),
                 TokenKind::Modifiers,
                 TokenType::keywordPrivate,
-                13,
+                14,
                 13,
             ),
             Token::new(
                 String::from("protected"),
                 TokenKind::Modifiers,
                 TokenType::KeywordProtected,
-                14,
+                15,
                 14,
             ),
             Token::new(
                 String::from("case"),
                 TokenKind::Keyword,
                 TokenType::KeywordCase,
-                15,
+                16,
                 15,
             ),
             Token::new(
                 String::from("static"),
                 TokenKind::Modifiers,
                 TokenType::KeywordStatic,
-                16,
+                17,
                 16,
             ),
             Token::new(
                 String::from("const"),
                 TokenKind::Keyword,
                 TokenType::KeywordConst,
-                17,
+                18,
                 17,
             ),
             Token::new(
                 String::from("default"),
                 TokenKind::Keyword,
                 TokenType::KeywordDefault,
-                18,
+                19,
                 18,
             ),
             Token::new(
                 String::from("return"),
                 TokenKind::Keyword,
                 TokenType::KeywordReturn,
-                19,
+                20,
                 19,
             ),
         ];
-        assert_eq!(tok_vector, tok.tokenize());
+        assert_eq!(expected, tok.tokenize());
     }
 
     #[test]
     fn test_tokenize_types() {
         let text = read_file("src/test/resources/tokenize_types.cpp");
         let mut tok = Tokenizer::new(&text);
-        let tok_vector = vec![
+        let expected = vec![
             Token::new(
                 String::from("int"),
                 TokenKind::DataTypes,
                 TokenType::Integer,
-                0,
+                1,
                 0,
             ),
             Token::new(
                 String::from("short"),
                 TokenKind::DataTypes,
                 TokenType::Short,
-                1,
+                2,
                 1,
             ),
             Token::new(
                 String::from("long"),
                 TokenKind::DataTypes,
                 TokenType::Long,
-                2,
+                3,
                 2,
             ),
             Token::new(
                 String::from("float"),
                 TokenKind::DataTypes,
                 TokenType::Float,
-                3,
+                4,
                 3,
             ),
             Token::new(
                 String::from("double"),
                 TokenKind::DataTypes,
                 TokenType::Double,
-                4,
+                5,
                 4,
             ),
             Token::new(
                 String::from("char"),
                 TokenKind::DataTypes,
                 TokenType::Character,
-                5,
+                6,
                 5,
             ),
             Token::new(
                 String::from("bool"),
                 TokenKind::DataTypes,
                 TokenType::Boolean,
-                6,
+                7,
                 6,
             ),
             Token::new(
                 String::from("void"),
                 TokenKind::DataTypes,
                 TokenType::Void,
-                7,
+                8,
                 7,
             ),
             Token::new(
                 String::from("typedef"),
                 TokenKind::Typedef,
                 TokenType::Typedef,
-                8,
+                9,
                 8,
             ),
         ];
-        assert_eq!(tok_vector, tok.tokenize());
+        assert_eq!(expected, tok.tokenize());
     }
 
     #[test]
     fn test_tokenize_comments() {
         let text = read_file("src/test/resources/tokenize_comments.cpp");
         let mut tok = Tokenizer::new(&text);
-        let tok_vector = vec![
+        let expected = vec![
             Token::new(
                 String::from("//Hello World"),
                 TokenKind::Comments,
                 TokenType::SingleLineComment,
-                0,
+                1,
                 0,
             ),
             Token::new(
-                String::from("/** hello\n * world\n */"),
+                String::from("/** hello\n * world\n * this is multi\n * line comment\n * Do not modify the code below, i have no\n * idea what it does, but needed very much\n */"),
                 TokenKind::Comments,
                 TokenType::MultilineComment,
-                1,
+                2,
                 1,
             ),
             Token::new(
                 String::from("// Goodbye"),
                 TokenKind::Comments,
                 TokenType::SingleLineComment,
-                2,
+                9,
                 2,
             ),
         ];
-        assert_eq!(tok_vector, tok.tokenize());
+        let result = tok.tokenize();
+        let mut index: usize = 0;
+        while index < expected.len() {
+            assert_eq!(
+                expected[index], result[index],
+                "\nTest failed for index {}",
+                index
+            );
+            index += 1;
+        }
     }
 
     #[test]
     fn test_tokenize_operators() {
         let text = read_file("src/test/resources/tokenize_operators.cpp");
         let mut tok = Tokenizer::new(&text);
-        let tok_vector = vec![
+        let expected = vec![
             Token::new(
                 String::from("++"),
                 TokenKind::UnaryOperators,
                 TokenType::Increment,
-                0,
+                1,
                 0,
             ),
             Token::new(
                 String::from("--"),
                 TokenKind::UnaryOperators,
                 TokenType::Decrement,
-                1,
+                2,
                 1,
             ),
             Token::new(
                 String::from("~"),
                 TokenKind::UnaryOperators,
                 TokenType::BitwiseNegate,
-                2,
+                3,
                 2,
             ),
             Token::new(
                 String::from("!"),
                 TokenKind::UnaryOperators,
                 TokenType::LogicalNot,
-                3,
+                4,
                 3,
             ),
             Token::new(
                 String::from("+"),
                 TokenKind::BinaryOperators,
                 TokenType::Plus,
-                4,
+                5,
                 4,
             ),
             Token::new(
                 String::from("-"),
                 TokenKind::BinaryOperators,
                 TokenType::Minus,
-                5,
+                6,
                 5,
             ),
             Token::new(
                 String::from("/"),
                 TokenKind::BinaryOperators,
                 TokenType::Divide,
-                6,
+                7,
                 6,
             ),
             Token::new(
                 String::from("*"),
                 TokenKind::BinaryOperators,
                 TokenType::Multiplication,
-                7,
+                8,
                 7,
             ),
             Token::new(
                 String::from("%"),
                 TokenKind::BinaryOperators,
                 TokenType::Module,
-                8,
+                9,
                 8,
             ),
             Token::new(
                 String::from(">"),
                 TokenKind::BinaryOperators,
                 TokenType::GreaterThan,
-                9,
+                10,
                 9,
             ),
             Token::new(
                 String::from(">="),
                 TokenKind::BinaryOperators,
                 TokenType::GreaterThanOrEqual,
-                10,
+                11,
                 10,
             ),
             Token::new(
                 String::from(">>"),
                 TokenKind::BinaryOperators,
                 TokenType::BitwiseRightShift,
-                11,
+                12,
                 11,
             ),
             Token::new(
                 String::from("<"),
                 TokenKind::BinaryOperators,
                 TokenType::LessThan,
-                12,
+                13,
                 12,
             ),
             Token::new(
                 String::from("<="),
                 TokenKind::BinaryOperators,
                 TokenType::LessThanOrEqual,
-                13,
+                14,
                 13,
             ),
             Token::new(
                 String::from("<<"),
                 TokenKind::BinaryOperators,
                 TokenType::BitwiseLeftShift,
-                14,
+                15,
                 14,
             ),
             Token::new(
                 String::from("=="),
                 TokenKind::BinaryOperators,
                 TokenType::Equal,
-                15,
+                16,
                 15,
             ),
             Token::new(
                 String::from("!="),
                 TokenKind::BinaryOperators,
                 TokenType::NotEqual,
-                16,
+                17,
                 16,
             ),
             Token::new(
                 String::from("&"),
                 TokenKind::BinaryOperators,
                 TokenType::BitwiseAnd,
-                17,
+                18,
                 17,
             ),
             Token::new(
                 String::from("&&"),
                 TokenKind::BinaryOperators,
                 TokenType::LogicalAnd,
-                18,
+                19,
                 18,
             ),
             Token::new(
                 String::from("|"),
                 TokenKind::BinaryOperators,
                 TokenType::BitwiseOr,
-                19,
+                20,
                 19,
             ),
             Token::new(
                 String::from("||"),
                 TokenKind::BinaryOperators,
                 TokenType::LogicalOr,
-                20,
+                21,
                 20,
             ),
             Token::new(
                 String::from("="),
                 TokenKind::AssignmentOperators,
                 TokenType::Assignment,
-                21,
+                22,
                 21,
             ),
             Token::new(
                 String::from("+="),
                 TokenKind::AssignmentOperators,
                 TokenType::PlusEqual,
-                22,
+                23,
                 22,
             ),
             Token::new(
                 String::from("-="),
                 TokenKind::AssignmentOperators,
                 TokenType::MinusEqual,
-                23,
+                24,
                 23,
             ),
             Token::new(
                 String::from("/="),
                 TokenKind::AssignmentOperators,
                 TokenType::DivideEqual,
-                24,
+                25,
                 24,
             ),
             Token::new(
                 String::from("%="),
                 TokenKind::AssignmentOperators,
                 TokenType::ModuleEqual,
-                25,
+                26,
                 25,
             ),
             Token::new(
                 String::from("->"),
                 TokenKind::SpecialChars,
                 TokenType::Arrow,
-                26,
+                27,
                 26,
             ),
             Token::new(
                 String::from("::"),
                 TokenKind::SpecialChars,
                 TokenType::ScopeResolution,
-                27,
+                28,
                 27,
             ),
             Token::new(
                 String::from("?"),
                 TokenKind::BinaryOperators,
                 TokenType::TernaryOpetator,
-                28,
+                29,
                 28,
             ),
         ];
-        debug_assert_eq!(tok_vector, tok.tokenize());
+        let result = tok.tokenize();
+        let mut index = 0;
+        while index < expected.len() {
+            assert_eq!(
+                expected[index], result[index],
+                "\nTest failed for index {}",
+                index
+            );
+            index += 1;
+        }
     }
 
     #[test]
     fn test_tokenize_punctuations() {
         let text = read_file("src/test/resources/tokenize_punctuations.cpp");
         let mut tok = Tokenizer::new(&text);
-        let tok_vector = vec![
+        let expected = vec![
             Token::new(
                 String::from("{"),
                 TokenKind::SpecialChars,
                 TokenType::LeftCurlyBrace,
-                0,
+                1,
                 0,
             ),
             Token::new(
                 String::from("}"),
                 TokenKind::SpecialChars,
                 TokenType::RightCurlyBrace,
-                1,
+                2,
                 1,
             ),
             Token::new(
                 String::from("("),
                 TokenKind::SpecialChars,
                 TokenType::LeftBracket,
-                2,
+                3,
                 2,
             ),
             Token::new(
                 String::from(")"),
                 TokenKind::SpecialChars,
                 TokenType::RightBracket,
-                3,
+                4,
                 3,
             ),
             Token::new(
                 String::from("["),
                 TokenKind::SpecialChars,
                 TokenType::LeftSquareBracket,
-                4,
+                5,
                 4,
             ),
             Token::new(
                 String::from("]"),
                 TokenKind::SpecialChars,
                 TokenType::RightSquareBracket,
-                5,
+                6,
                 5,
             ),
             Token::new(
                 String::from(":"),
                 TokenKind::SpecialChars,
                 TokenType::Colon,
-                6,
+                7,
                 6,
             ),
             Token::new(
                 String::from(";"),
                 TokenKind::SpecialChars,
                 TokenType::Semicolon,
-                7,
+                8,
                 7,
             ),
             Token::new(
                 String::from(","),
                 TokenKind::SpecialChars,
                 TokenType::Comma,
-                8,
+                9,
                 8,
             ),
         ];
-        assert_eq!(tok_vector, tok.tokenize());
+        let result = tok.tokenize();
+        let mut index = 0;
+        while index < expected.len() {
+            assert_eq!(
+                expected[index], result[index],
+                "\nTest failed for index {}",
+                index
+            );
+            index += 1;
+        }
     }
 
     #[test]
     fn test_tokenize_values() {
         let text = read_file("src/test/resources/tokenize_values.cpp");
         let mut tok = Tokenizer::new(&text);
-        let tok_vector = vec![
+        let expected = vec![
             Token::new(String::from("\"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ`1234567890-=[]\\;\',./~!@#$%^&*()_+{}|:\\\"<>?\\\"\'\""),
                        TokenKind::Values,
                        TokenType::StringValue,
-                       0,
+                       1,
                        0),
-            Token::new(String::from("'a'"), TokenKind::Values, TokenType::CharValue, 1, 1),
-            Token::new(String::from("\'\\\'\'"), TokenKind::Values, TokenType::CharValue, 2, 2),
-            Token::new(String::from("\'\\\"\'"), TokenKind::Values, TokenType::CharValue, 3, 3),
-            Token::new(String::from("\'\\\\\'"), TokenKind::Values, TokenType::CharValue, 4, 4),
-            Token::new(String::from("1234567890"), TokenKind::Values, TokenType::NumberInteger, 5, 5),
+            Token::new(String::from("'a'"), TokenKind::Values, TokenType::CharValue, 2, 1),
+            Token::new(String::from("\'\\\'\'"), TokenKind::Values, TokenType::CharValue, 3, 2),
+            Token::new(String::from("\'\\\"\'"), TokenKind::Values, TokenType::CharValue, 4, 3),
+            Token::new(String::from("\'\\\\\'"), TokenKind::Values, TokenType::CharValue, 5, 4),
+            Token::new(String::from("1234567890"), TokenKind::Values, TokenType::NumberInteger, 6, 5),
             Token::new(String::from("1234567890.0987654321"),
                        TokenKind::Values,
                        TokenType::NumberFloat,
-                       6,
+                       7,
                        6),
-            Token::new(String::from("true"), TokenKind::Values, TokenType::True, 7, 7),
-            Token::new(String::from("false"), TokenKind::Values, TokenType::False, 8, 8)];
-        assert_eq!(tok_vector, tok.tokenize());
+            Token::new(String::from("true"), TokenKind::Values, TokenType::True, 8, 7),
+            Token::new(String::from("false"), TokenKind::Values, TokenType::False, 9, 8)];
+        let result = tok.tokenize();
+        let mut index = 0;
+        while index < expected.len() {
+            assert_eq!(
+                expected[index], result[index],
+                "\nTest failed for index {}",
+                index
+            );
+            index += 1;
+        }
     }
 
     #[test]
     fn test_tokenize_ids() {
         let text = read_file("src/test/resources/tokenize_ids.cpp");
         let mut tok = Tokenizer::new(&text);
-        let tok_vector = vec![
+        let expected = vec![
             Token::new(
                 String::from("_"),
                 TokenKind::Identifiers,
                 TokenType::Identifier,
-                0,
+                1,
                 0,
             ),
             Token::new(
                 String::from("_1123abcd_deff04"),
                 TokenKind::Identifiers,
                 TokenType::Identifier,
-                1,
+                2,
                 1,
             ),
             Token::new(
                 String::from("abcd_deff04_"),
                 TokenKind::Identifiers,
                 TokenType::Identifier,
-                2,
+                3,
                 2,
             ),
             Token::new(
                 String::from("integer"),
                 TokenKind::Identifiers,
                 TokenType::Identifier,
-                3,
+                4,
                 3,
             ),
             Token::new(
                 String::from("main"),
                 TokenKind::Identifiers,
                 TokenType::Main,
-                4,
+                5,
                 4,
             ),
         ];
-        assert_eq!(tok_vector, tok.tokenize());
+        let result = tok.tokenize();
+
+        let mut index = 0;
+        while index < expected.len() {
+            assert_eq!(
+                expected[index], result[index],
+                "\nTest failed for index {}",
+                index
+            );
+            index += 1;
+        }
     }
 }

--- a/src/library/parser/mod.rs
+++ b/src/library/parser/mod.rs
@@ -1,3 +1,6 @@
 mod helper;
 pub mod parser;
 mod rust_type;
+
+#[cfg(test)]
+mod parser_test;

--- a/src/library/parser/parser.rs
+++ b/src/library/parser/parser.rs
@@ -108,7 +108,6 @@ impl Parser {
                     temp_lexeme.push(lexeme[head].clone());
                     stream.append(&mut self.parse_typdef(&temp_lexeme));
                     head += 1;
-                    // println!("{}", lexeme[head].get_token_value());
                     temp_lexeme.clear();
                 }
                 // matches any datatype
@@ -183,7 +182,6 @@ impl Parser {
                                 temp_lexeme.push(l);
                                 head += 1;
                             }
-                            //  println!(" {:?}", temp_lexeme);
                             // parse declaration
                             stream.append(&mut self.parse_declaration(&temp_lexeme, false));
                             temp_lexeme.clear();
@@ -197,7 +195,6 @@ impl Parser {
                             temp_lexeme.push(lexeme[head].clone());
                             stream.append(&mut self.parse_declaration(&temp_lexeme, false));
                             head += 1;
-                            // println!("{}", lexeme[head].get_token_value());
                             temp_lexeme.clear();
                         }
 
@@ -389,7 +386,6 @@ impl Parser {
                                     temp_lexeme.push(l);
                                     head += 1;
                                 }
-                                //  println!(" {:?}", temp_lexeme);
                                 // parse declaration
                                 stream.append(&mut self.parse_declaration(&temp_lexeme, false));
                             } else {
@@ -495,7 +491,6 @@ impl Parser {
                 }
 
                 (TokenKind::UnaryOperators, _) => {
-                    println!(" 564 : unop");
                     stream.push(lexeme[head + 1].get_token_value());
                     stream.push(match lexeme[head].get_token_type() {
                         Increment => "+=1".to_string(),
@@ -593,8 +588,6 @@ impl Parser {
 
                     if t != lexeme.len() - 1 {
                         while lexeme[head].get_token_type() != Semicolon {
-                            // println!("{:?}", lexeme[head]);
-
                             stream.push(lexeme[head].get_token_value());
                             head += 1;
                         }
@@ -758,8 +751,6 @@ impl Parser {
      * into rust equivalent arguments
      */
     fn parse_arguments(&mut self, lexeme: &Vec<Token>) -> Vec<String> {
-        println!("\n Parse Arguments \n {:?}", lexeme);
-
         let mut stream: Vec<String> = Vec::new();
         let mut head: usize = 0;
         while head < lexeme.len() {
@@ -771,19 +762,13 @@ impl Parser {
                 declaration_lexeme.push(lexeme[head].clone());
 
                 head += 1;
-                println!(" Head {} , len {} ", head, lexeme.len());
             }
-            //            declaration_lexeme.push(lexeme[head].clone());
             head += 1;
 
             let mut parsed_argument = self.parse_declaration(&declaration_lexeme, true);
 
-            println!("Parsed argumnent {:?}", parsed_argument);
-
             stream.append(&mut parsed_argument);
-
             stream.push(",".to_string());
-            // push identifier
         }
         stream
     }
@@ -889,7 +874,6 @@ impl Parser {
                 Semicolon | Comma => {
                     // used enum value in the symbol table
                     sym.symbol_type = type_token.get_token_type();
-                    //       println!("SYM TYPE {}",sym.typ);
                     self.sym_tab.push(sym.clone());
                 }
                 //int * a ;
@@ -1393,7 +1377,6 @@ impl Parser {
         let m = 3;
 
         let mut tstream: Vec<String> = Vec::new();
-        // if lexeme[0].get_token_type() == OP_MUL {println!("DEBUG @1272 "); m+=1; n+=1;thead+=1;}
         if lexeme[n].get_token_kind() == TokenKind::UnaryOperators {
             while lexeme[thead].get_token_type() != Semicolon {
                 lexeme1.push(lexeme[thead].clone());
@@ -1480,7 +1463,6 @@ impl Parser {
         while lexeme[thead].get_token_type() != Semicolon {
             if lexeme[thead].get_token_kind() == TokenKind::UnaryOperators {
                 if lexeme[thead].get_token_type() == SizeOf {
-                    //println!(" {:?} ",lexeme);
                     stream.push("std::mem::size_of(".to_string());
                     thead += 2;
                     if lexeme[thead].get_token_kind() == TokenKind::DataTypes {
@@ -1495,7 +1477,6 @@ impl Parser {
                     stream.push(")".to_string());
                     thead += 1;
                 } else {
-                    //println!(" 1542 :unop");
                     //incase of post
                     if typ == Identifier {
                         tstream.push(prev_id.clone());

--- a/src/library/parser/parser.rs
+++ b/src/library/parser/parser.rs
@@ -659,7 +659,12 @@ impl Parser {
     fn print_lexemes(lexeme: &Vec<Token>, start: usize, end: usize) {
         println!("----------lexeme-start------------");
         for i in start..end {
-            println!("{}> {}", i, lexeme[i].get_token_value());
+            println!(
+                "Line Num {} , {}> {}",
+                lexeme[i].get_token_line_num(),
+                i,
+                lexeme[i].get_token_value()
+            );
         }
         println!("----------lexeme-end------------");
     }
@@ -755,7 +760,6 @@ impl Parser {
         let mut head: usize = 0;
         while head < lexeme.len() {
             let mut declaration_lexeme: Vec<Token> = Vec::new();
-
             while head < lexeme.len() && lexeme[head].get_token_type() != Comma {
                 //create a subset of argument declaration
 

--- a/src/library/parser/parser_test.rs
+++ b/src/library/parser/parser_test.rs
@@ -1,0 +1,5 @@
+#[cfg(test)]
+#[test]
+fn test_that_works() {
+    assert_eq!(1, 1);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,19 +140,21 @@ fn invoke(settings: &Settings) {
         let mut tok = Tokenizer::new(&text);
         print!("Tokenizing");
 
-        //let out: Vec<String> = Vec::new();
+        let out: Vec<String> = Vec::new();
         let tokens = tok.tokenize();
-        // tok.tokenize();
-        // let mut ln = 0;
-        // for token in &tokens {
-        //     let mut token_value = token.get_token_value();
-        //     print!("{:?}\n",token);
-        //     if token.get_token_line_num() != ln {
-        //         token_value = "\n".to_string() + &token_value[..];
-        //     }
-        //     ln = token.get_token_line_num();
-        //     out.push(token_value);
-        // }
+
+        for token in &tokens {
+            println!(
+                "{:?} : {}",
+                token.get_token_line_num(),
+                token.get_token_value()
+            );
+            //     if token.get_token_line_num() != ln {
+            //         token_value = "\n".to_string() + &token_value[..];
+            //     }
+            //     ln = token.get_token_line_num();
+            //     out.push(token_value);
+        }
 
         print!("Invoking Parser ....");
 

--- a/src/test/resources/tokenize_comments.cpp
+++ b/src/test/resources/tokenize_comments.cpp
@@ -1,5 +1,9 @@
 //Hello World
 /** hello
  * world
+ * this is multi
+ * line comment
+ * Do not modify the code below, i have no
+ * idea what it does, but needed very much
  */
 // Goodbye


### PR DESCRIPTION
* Fix panic on parsing argument.
* delegate  parsing each argument declaration to declaration parser
* align token line number with the source file line number, multi-line comment had messed up the line number.